### PR TITLE
Update home-assistant to version 2024.2.3

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 2024.2.1
+appVersion: 2024.2.3
 description: Home Assistant helm package
 name: home-assistant
-version: 1.0.17
+version: 1.0.18
 kubeVersion: ">=1.16.0-0"
 keywords:
   - home-assistant
@@ -16,7 +16,7 @@ maintainers:
 dependencies:
   - name: common
     repository: https://bjw-s.github.io/helm-charts
-    version: 2.5.0
+    version: 2.6.0
   - name: postgresql
     version: 13.2.11
     repository: https://charts.bitnami.com/bitnami
@@ -32,4 +32,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Update to home-assistant version 2024.2.0
+      description: Update to home-assistant version 2024.2.3
+    - kind: changed
+      description: Update base chart to 2.6.0

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -1,6 +1,6 @@
 # home-assistant
 
-![Version: 1.0.17](https://img.shields.io/badge/Version-1.0.17-informational?style=flat-square) ![AppVersion: 2024.2.1](https://img.shields.io/badge/AppVersion-2024.2.1-informational?style=flat-square)
+![Version: 1.0.18](https://img.shields.io/badge/Version-1.0.18-informational?style=flat-square) ![AppVersion: 2024.2.3](https://img.shields.io/badge/AppVersion-2024.2.3-informational?style=flat-square)
 
 Home Assistant helm package
 
@@ -22,7 +22,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://bjw-s.github.io/helm-charts | common | 2.5.0 |
+| https://bjw-s.github.io/helm-charts | common | 2.6.0 |
 | https://charts.bitnami.com/bitnami | influxdb | 5.10.2 |
 | https://charts.bitnami.com/bitnami | mariadb | 14.1.2 |
 | https://charts.bitnami.com/bitnami | postgresql | 13.2.11 |


### PR DESCRIPTION
Update home-asssistant chart to version 2024.2.3 and base helm chart to 2.6.0