### PR TITLE
Set Renovate gitAuthor to fix default identity warning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "gitAuthor": "egeback <3228822+egeback@users.noreply.github.com>",
   "dependencyDashboard": true,
   "rebaseWhen": "behind-base-branch",
   "customManagers": [


### PR DESCRIPTION
## Summary
- Self-hosted Renovate warns that it's using the default `renovate@whitesourcesoftware.com` git author, an account we don't control and can't sign commits for.
- Pin `gitAuthor` in `.github/renovate.json` to `egeback <3228822+egeback@users.noreply.github.com>` so Renovate commits/PRs are attributed to our own GitHub identity.

## Test plan
- [ ] Merge and confirm next Renovate run no longer shows the gitAuthor warning
- [ ] Confirm new Renovate PR commits show `egeback` as author